### PR TITLE
Add bin & lastFour to the PaymentCardData struct

### DIFF
--- a/EvervaultIOSApp/EvervaultIOSApp/Views/CreditCardInputView.swift
+++ b/EvervaultIOSApp/EvervaultIOSApp/Views/CreditCardInputView.swift
@@ -18,6 +18,18 @@ struct CreditCardInputView: View {
                         .bold()
                     Text(cardData.card.number)
                 }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Bin:")
+                        .bold()
+                    Text(cardData.card.bin)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Last 4:")
+                        .bold()
+                    Text(cardData.card.lastFour)
+                }
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("CVC:")

--- a/Sources/EvervaultInputs/Model/PaymentCardData+Validation.swift
+++ b/Sources/EvervaultInputs/Model/PaymentCardData+Validation.swift
@@ -18,6 +18,12 @@ internal extension PaymentCardData {
         let formattedNumber = CreditCardFormatter.formatCardNumber(number)
 
         self.card.number = formattedNumber
+        if validator.isValid {
+            self.card.bin = String(number.prefix(8));
+        }
+        if validator.isValid {
+            self.card.lastFour = String(number.suffix(4));
+        }
         self.card.cvc = String(cvc.numbers.prefix(CreditCardValidator.maxCvcLength(for: self.card.type)))
 
         let expiryParts = expiry.split(separator: "/")
@@ -41,7 +47,6 @@ internal extension PaymentCardData {
                 self.error = .invalidMonth
             }
         }
-
     }
 
     mutating func updateNumber(_ number: String) {

--- a/Sources/EvervaultInputs/Model/PaymentCardData.swift
+++ b/Sources/EvervaultInputs/Model/PaymentCardData.swift
@@ -32,6 +32,12 @@ public struct PaymentCard: Equatable {
 
     /// The number of the credit card.
     public var number: String = ""
+    
+    /// The first 8 digits of the card number.
+    public var bin: String = ""
+    
+    /// The last 4 digits of the card number.
+    public var lastFour: String = ""
 
     /// The cvc (Card Verification Code) of the credit card.
     public var cvc: String = ""


### PR DESCRIPTION
# Why
The JS SDK returns the bin & lastFour part of the card object. We want to introduce that feature in our mobile SDKs.

# How
Populate the `bin` and `lastFour` attributes of the `PaymentCardData` struct when a card number is valid.