### PR TITLE
Update bin to be the 6 first digits of the PAN for amex cards

### DIFF
--- a/Sources/EvervaultInputs/Model/PaymentCardData+Validation.swift
+++ b/Sources/EvervaultInputs/Model/PaymentCardData+Validation.swift
@@ -19,10 +19,8 @@ internal extension PaymentCardData {
 
         self.card.number = formattedNumber
         if validator.isValid {
-            self.card.bin = String(number.prefix(8));
-        }
-        if validator.isValid {
-            self.card.lastFour = String(number.suffix(4));
+            self.card.bin = (self.card.type == .amex) ? String(number.prefix(6)) : String(number.prefix(8))
+            self.card.lastFour = String(number.suffix(4))
         }
         self.card.cvc = String(cvc.numbers.prefix(CreditCardValidator.maxCvcLength(for: self.card.type)))
 


### PR DESCRIPTION
# Why
We currently return the `bin` as the first 8 digits of the pan regardless of the card brand. We need to update that logic to be 6 digits for amex to match the logic in our other SDKs.

# How
Return first 6 digits for amex cards