### PR TITLE
Remove formatting when encrypting card numbers

### DIFF
--- a/Sources/EvervaultInputs/UI/PaymentCardInput.swift
+++ b/Sources/EvervaultInputs/UI/PaymentCardInput.swift
@@ -77,7 +77,7 @@ public struct PaymentCardInput: View {
         .onChange(of: self.rawCardData.card.number) { number in
             updateCardData { cardData in
                 var updatedCardData = cardData
-                updatedCardData.card.number = number.isEmpty ? "" : try await Evervault.shared.encrypt(number) as? String ?? ""
+                updatedCardData.card.number = number.isEmpty ? "" : try await Evervault.shared.encrypt(number.replacingOccurrences(of: " ", with: "")) as? String ?? ""
                 return updatedCardData
             }
         }


### PR DESCRIPTION
# Why
Card numbers are currently encrypted as `4242 4242 4242 4242` instead of `4242424242424242`.

# How
Remove all spaces in PAN before encryption