### PR TITLE
[SPE-1036] Make PCRS optional

### DIFF
--- a/.changeset/purple-flowers-brake.md
+++ b/.changeset/purple-flowers-brake.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": minor
+---
+
+Allow partial set of PCRs to be specified for Cage attestation. Make PCR strings optional.

--- a/EvervaultIOSApp/EvervaultIOSApp/Views/CageView.swift
+++ b/EvervaultIOSApp/EvervaultIOSApp/Views/CageView.swift
@@ -33,24 +33,29 @@ struct CageView: View {
         }
         .padding()
         .task {
-            let url = URL(string: "https://\(cageName).\(appId).cages.evervault.com/attestation-doc")!
+            let url = URL(string: "https://\(cageName).\(appId).cages.evervault.com/hello")!
             let urlSession = Evervault.cageSession(
-                cageAttestationData: AttestationData(
-                    cageName: cageName,
-                    pcrs: PCRs(
-                        // Replace with legitimate PCR strings when not in debug mode
-                        pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                        pcr1: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                        pcr2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                        pcr8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                cageAttestationData:
+                    AttestationData(
+                        cageName: cageName,
+                        pcrs: 
+                            PCRs( //Can use a partial set of PCRs
+                              pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                        ),
+                            PCRs( //Or can use a full set of PCRs
+                            
+                              pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                              pcr1: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                              pcr2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                              pcr8: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                        )
                     )
-                )
-            )
+            );
 
             do {
                 let response = try await urlSession.data(from: url)
-                let cageRespone = try! JSONDecoder().decode(CageResponse.self, from: response.0)
-                responseText = cageRespone.response
+                let cageResponse = try! JSONDecoder().decode(CageResponse.self, from: response.0)
+                responseText = cageResponse.response
             } catch {
                 responseText = error.localizedDescription
                 print("Error: \(error.localizedDescription)")

--- a/Sources/EvervaultCages/AttestationSessionDelegate.swift
+++ b/Sources/EvervaultCages/AttestationSessionDelegate.swift
@@ -56,12 +56,12 @@ public struct AttestationDataWithApp {
 
 
 public struct PCRs: Decodable {
-    public let pcr0: String
-    public let pcr1: String
-    public let pcr2: String
-    public let pcr8: String
+    public let pcr0: String?
+    public let pcr1: String?
+    public let pcr2: String?
+    public let pcr8: String?
 
-    public init(pcr0: String, pcr1: String, pcr2: String, pcr8: String) {
+    public init(pcr0: String?, pcr1: String?, pcr2: String?, pcr8: String?) {
         self.pcr0 = pcr0
         self.pcr1 = pcr1
         self.pcr2 = pcr2
@@ -107,27 +107,21 @@ public class AttestationSessionDelegate: NSObject, URLSessionDelegate {
             }
 
             let pcrsAtIndex = pcrs[index]
-            let pcr0CStr = pcrsAtIndex.pcr0.utf8CString
-            let pcr1CStr = pcrsAtIndex.pcr1.utf8CString
-            let pcr2CStr = pcrsAtIndex.pcr2.utf8CString
-            let pcr8CStr = pcrsAtIndex.pcr8.utf8CString
+            let pcr0CStr = pcrsAtIndex.pcr0?.withCString { $0 } ?? nil
+            let pcr1CStr = pcrsAtIndex.pcr1?.withCString { $0 } ?? nil
+            let pcr2CStr = pcrsAtIndex.pcr2?.withCString { $0 } ?? nil
+            let pcr8CStr = pcrsAtIndex.pcr8?.withCString { $0 } ?? nil
 
-            return pcr0CStr.withUnsafeBufferPointer { pcr0Bytes in
-                pcr1CStr.withUnsafeBufferPointer { pcr1Bytes in
-                    pcr2CStr.withUnsafeBufferPointer { pcr2Bytes in
-                        pcr8CStr.withUnsafeBufferPointer { pcr8Bytes in
-                            pcrsArray.append(AttestationBindings.PCRs(
-                                pcr_0: pcr0Bytes.baseAddress!,
-                                pcr_1: pcr1Bytes.baseAddress!,
-                                pcr_2: pcr2Bytes.baseAddress!,
-                                pcr_8: pcr8Bytes.baseAddress!
-                            ))
+            let pcrStruct = AttestationBindings.PCRs(
+                pcr_0: pcr0CStr,
+                pcr_1: pcr1CStr,
+                pcr_2: pcr2CStr,
+                pcr_8: pcr8CStr
+            )
 
-                            return attestConnectionRecursive(pcrsArray: &pcrsArray, pcrs: pcrs, index: index + 1)
-                        }
-                    }
-                }
-            }
+            pcrsArray.append(pcrStruct)
+
+            return attestConnectionRecursive(pcrsArray: &pcrsArray, pcrs: pcrs, index: index + 1)
         }
 
         guard let pcrs = cageAttestationData.first(where: { $0.cageName == cageName }) else {
@@ -207,28 +201,21 @@ public class TrustedAttestationSessionDelegate: NSObject, URLSessionDelegate {
                 }
                 
                 let pcrsAtIndex = pcrs[index]
-                let pcr0CStr = pcrsAtIndex.pcr0.utf8CString
-                let pcr1CStr = pcrsAtIndex.pcr1.utf8CString
-                let pcr2CStr = pcrsAtIndex.pcr2.utf8CString
-                let pcr8CStr = pcrsAtIndex.pcr8.utf8CString
-                
-                return pcr0CStr.withUnsafeBufferPointer { pcr0Bytes in
-                    pcr1CStr.withUnsafeBufferPointer { pcr1Bytes in
-                        pcr2CStr.withUnsafeBufferPointer { pcr2Bytes in
-                            pcr8CStr.withUnsafeBufferPointer { pcr8Bytes in
-                                pcrsArray.append(AttestationBindings.PCRs(
-                                    pcr_0: pcr0Bytes.baseAddress!,
-                                    pcr_1: pcr1Bytes.baseAddress!,
-                                    pcr_2: pcr2Bytes.baseAddress!,
-                                    pcr_8: pcr8Bytes.baseAddress!
-                                ))
-                                
-                                let attestResult = attestConnectionRecursive(pcrsArray: &pcrsArray, pcrs: pcrs, index: index + 1)
-                                return attestResult
-                            }
-                        }
-                    }
-                }
+                let pcr0CStr = pcrsAtIndex.pcr0?.withCString { $0 } ?? nil
+                let pcr1CStr = pcrsAtIndex.pcr1?.withCString { $0 } ?? nil
+                let pcr2CStr = pcrsAtIndex.pcr2?.withCString { $0 } ?? nil
+                let pcr8CStr = pcrsAtIndex.pcr8?.withCString { $0 } ?? nil
+
+                let pcrStruct = AttestationBindings.PCRs(
+                    pcr_0: pcr0CStr,
+                    pcr_1: pcr1CStr,
+                    pcr_2: pcr2CStr,
+                    pcr_8: pcr8CStr
+                )
+
+                pcrsArray.append(pcrStruct)
+
+                return attestConnectionRecursive(pcrsArray: &pcrsArray, pcrs: pcrs, index: index + 1)
             }
             
             guard let attestationData = self.cageAttestationData.first(where: { $0.identifier == cageIdentifier }) else {

--- a/Sources/EvervaultCages/AttestationSessionDelegate.swift
+++ b/Sources/EvervaultCages/AttestationSessionDelegate.swift
@@ -61,7 +61,7 @@ public struct PCRs: Decodable {
     public let pcr2: String?
     public let pcr8: String?
 
-    public init(pcr0: String?, pcr1: String?, pcr2: String?, pcr8: String?) {
+    public init(pcr0: String? = nil, pcr1: String? = nil, pcr2: String? = nil, pcr8: String? = nil) {
         self.pcr0 = pcr0
         self.pcr1 = pcr1
         self.pcr2 = pcr2


### PR DESCRIPTION
# Why
A user should be able to specify a subset of the cages pcrs. Eg (just pcr8 if they want to just attest the signing cert)

# How
Update PCRs to be optional Strings in the PCR array. Initially thought we'd need new constructors and a pcr object everywhere but setting a String vs setting an optional String is the same so the struct initialisation doesn't break.