### PR TITLE
Fix changesets release - push tag that is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             echo "Tag already exists. No new release needed."
         else
             echo "Tag ($PACKAGE_VERSION) does not exist. Creating a new tag and a new release..."
-            git tag $PACKAGE_VERSION
+            git tag $PACKAGE_VERSION && git push origin $PACKAGE_VERSION
             echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
             CHANGELOG=$(awk '
                 BEGIN { recording=0; }


### PR DESCRIPTION
# Why
Release is failing ([failed action](https://github.com/evervault/evervault-ios/actions/runs/7260955411/job/19781169567))

```
tag 0.2.0 exists locally but has not been pushed to evervault/evervault-ios, please push it before continuing or specify the `--target` flag to create a new tag
```
# How
Push the tag after creating it