### PR TITLE
bugfix: nsnumber are not encrypted

### DIFF
--- a/.changeset/curvy-cars-sell.md
+++ b/.changeset/curvy-cars-sell.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": patch
+---
+
+Bugfix numbers to include Obj-c numbers

--- a/Sources/EvervaultCore/core/dataHandlers/NumberHandler.swift
+++ b/Sources/EvervaultCore/core/dataHandlers/NumberHandler.swift
@@ -5,7 +5,22 @@ internal struct NumberHandler: DataHandler {
     let encryptionService: EncryptionService
 
     func canEncrypt(data: Any) -> Bool {
-        data is any Numeric
+        return data is Int ||
+               data is Int8 ||
+               data is Int16 ||
+               data is Int32 ||
+               data is Int64 ||
+               data is UInt ||
+               data is UInt8 ||
+               data is UInt16 ||
+               data is UInt32 ||
+               data is UInt64 ||
+               data is Float ||
+               data is Double ||
+               data is CGFloat ||
+               data is Decimal ||
+               data is NSNumber &&
+               !(data is Bool)
     }
 
     func encrypt(data: Any, context: DataHandlerContext) throws -> Any {


### PR DESCRIPTION
# Why
We need a more expansive check on numbers then is Numeric. An integer send from Objective-C will be of type `NSNumber` and not be encrypted. As a boolean in Swift is represented as an Integer, a boolean is a Number so an explict check is needed as the function takes in `Any`

# How
Update the `canEncrypt` function to be more exhaustive then previous. 