### PR TITLE
Eoin/etr 1696 ios library missing info plist vars

### DIFF
--- a/.changeset/popular-kangaroos-chew.md
+++ b/.changeset/popular-kangaroos-chew.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": minor
+---
+
+Add privacy info to SDK and update attestation bindings

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AttestationBindings",
-            url: "https://github.com/evervault/evervault-ios/releases/download/0.0.5/AttestationBindings.xcframework.zip",
-            checksum: "77d9e009074b9c0bbaf524e36eec0b4ca08af7db9fd7d91f2da0e2241aeee44e"
+            url: "https://github.com/evervault/evervault-ios/releases/download/1.0.0/AttestationBindings.xcframework.zip",
+            checksum: "cf6fe337e5862519e569181f1ec5bb25fbb306252cbb5c7309fb484cb01fd4c7"
         ),
         .testTarget(
             name: "EvervaultCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .binaryTarget(
             name: "AttestationBindings",
             url: "https://github.com/evervault/evervault-ios/releases/download/1.0.0/AttestationBindings.xcframework.zip",
-            checksum: "cf6fe337e5862519e569181f1ec5bb25fbb306252cbb5c7309fb484cb01fd4c7"
+            checksum: "eacbe39e953e77c688ab1e051210dee07802c7787f5e60c32eb53ae338b9baeb"
         ),
         .testTarget(
             name: "EvervaultCoreTests",

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
# Why
iOS requires a privacy manifest to be included in third parties by May 2024. 

# How
- Include privacy manifest that says we only use data passed from the same app the SDK is installed within
- Bump the attestation doc crate to the new version which includes the `minimumOSVersion`