### PR TITLE
feat: use grep -w

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-node@v3
 
     - name: Install dependencies
-      run: npm install 
+      run: npm install
 
     - name: Create Release Pull Request
       id: changesets
@@ -35,7 +35,7 @@ jobs:
       run: |
         PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
-        if git tag | grep -q "$PACKAGE_VERSION"; then
+        if git tag | grep -w -q "$PACKAGE_VERSION"; then
             echo "Tag already exists. No new release needed."
         else
             echo "Tag ($PACKAGE_VERSION) does not exist. Creating a new tag and a new release..."


### PR DESCRIPTION
# Why
1.1.1 did not create a release at the CI does a fuzzy match for the version and it found the beta tag so didnt release

# How
- Do an exact match for the version with grep -w