### PR TITLE
fix: revert bindings change

### DIFF
--- a/.changeset/olive-colts-mix.md
+++ b/.changeset/olive-colts-mix.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": patch
+---
+
+revert bindings change

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AttestationBindings",
-            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.1/AttestationBindings.xcframework.zip",
-            checksum: "d2f46e5a01da62da153eef02190f2560cdaa4073d048b6ed890aa93afa50811c"
+            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.0/AttestationBindings.xcframework.zip",
+            checksum: "42c9b066eb75259f2e26c0f49d0736d7e4fb0e4b36c8d0f3643dda11957163d9"
         ),
         .testTarget(
             name: "EvervaultCoreTests",


### PR DESCRIPTION
# Why
Bindings are not in the correct format for a Swift package

# How
Reverting to know working version