### PR TITLE
Eoin/fix attestation bindings

### DIFF
--- a/.changeset/chilly-trainers-explain.md
+++ b/.changeset/chilly-trainers-explain.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": patch
+---
+
+Fix attestation bindings fat binary

--- a/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/project.pbxproj
+++ b/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/project.pbxproj
@@ -347,7 +347,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EvervaultIOSApp/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EvervaultIOSApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -381,7 +380,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EvervaultIOSApp/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				"EXCLUDED_ARCHS[sdk=*]" = arm64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EvervaultIOSApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/xcshareddata/xcschemes/EvervaultIOSApp.xcscheme
+++ b/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/xcshareddata/xcschemes/EvervaultIOSApp.xcscheme
@@ -54,7 +54,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/xcshareddata/xcschemes/EvervaultIOSApp.xcscheme
+++ b/EvervaultIOSApp/EvervaultIOSApp.xcodeproj/xcshareddata/xcschemes/EvervaultIOSApp.xcscheme
@@ -54,7 +54,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AttestationBindings",
-            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.4/AttestationBindings.xcframework.zip",
-            checksum: "3cf5d992689dd0070131290a75b400942881b3b107e1d7a87942269bdd369082"
+            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.1/AttestationBindings.xcframework.zip",
+            checksum: "444c0cb0baab41754d6052994e482e8f096befa7b40eb4e7f77fdcb1d0e52bc7"
         ),
         .testTarget(
             name: "EvervaultCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AttestationBindings",
-            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.1/AttestationBindings.xcframework.zip",
+            url: "https://github.com/evervault/evervault-ios/releases/download/1.1.5/AttestationBindings.xcframework.zip",
             checksum: "444c0cb0baab41754d6052994e482e8f096befa7b40eb4e7f77fdcb1d0e52bc7"
         ),
         .testTarget(


### PR DESCRIPTION
# Why
Universal fat binary generated by `lipo` did not include arm64 simulator build.

# How
- Link fixed attestation bindings
- Remove arm64 from excluded arch
- Run sample app in debug mode