### PR TITLE
feat: add evervault-pay apple pay ios as a reexported dependency

### DIFF
--- a/.changeset/many-hats-pump.md
+++ b/.changeset/many-hats-pump.md
@@ -1,0 +1,5 @@
+---
+"evervault-ios": major
+---
+
+Add Evervault Apple Pay to iOS SDK

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "evervault-pay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/evervault/evervault-pay.git",
+      "state" : {
+        "revision" : "d058bc450581bd4204dcc5eee1fb9a457cacffb1",
+        "version" : "0.0.20"
+      }
+    },
+    {
       "identity" : "mockingbird",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/birdrides/mockingbird.git",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/birdrides/mockingbird.git", .upToNextMinor(from: "0.20.0"))
+        .package(url: "https://github.com/birdrides/mockingbird.git", .upToNextMinor(from: "0.20.0")),
+        .package(
+            url: "https://github.com/evervault/evervault-pay.git",
+            from: "0.0.20"
+        ),
     ],
     targets: [
         .target(
@@ -34,6 +38,7 @@ let package = Package(
             name: "EvervaultInputs",
             dependencies: [
                 "EvervaultCore",
+                .product(name: "EvervaultPayment", package: "evervault-pay"),
             ],
             resources: [
                 .process("Resources")

--- a/Sources/EvervaultInputs/EvervaultInputs+EvervaultPayment.swift
+++ b/Sources/EvervaultInputs/EvervaultInputs+EvervaultPayment.swift
@@ -1,0 +1,8 @@
+//
+//  EvervaultInputs+EvervaultPayment.swift
+//  Evervault
+//
+//  Created by Jake Grogan on 08/07/2025.
+//
+
+@_exported import EvervaultPayment


### PR DESCRIPTION
# Why

- Add evervault-pay dependency to iOS SDK and reexport it

# How
Describe how you've approached the problem