### PR TITLE
chore: bump evervault-pay to version 0.0.21

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/evervault/evervault-pay.git",
       "state" : {
-        "revision" : "d058bc450581bd4204dcc5eee1fb9a457cacffb1",
-        "version" : "0.0.20"
+        "revision" : "da5e13cadb0db4b63dcedc4f4504058af85d7b09",
+        "version" : "0.0.21"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/birdrides/mockingbird.git", .upToNextMinor(from: "0.20.0")),
         .package(
             url: "https://github.com/evervault/evervault-pay.git",
-            from: "0.0.20"
+            from: "0.0.21"
         ),
     ],
     targets: [


### PR DESCRIPTION
# Why
We're releasing support for:
- Disbursements
- Recurring payments
- onShippingAddress to support handling shipping address changes
- onPaymentMethod to support handling changes to payment methods
- Pre transaction update support to update the transaction before the sheet is displayed
- Improved results handling - remove `onFinish` and `onError` and use `onResult` instead

# How
Describe how you've approached the problem